### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "DB::Rscs",
+    "license" : "BSD-2-Clause",
     "version" : "0.0.2",
     "description" : "A client library for the Ridiculously Simple Configuration System",
     "author" : "Brad Clawsie",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license