### PR TITLE
Fix provides section and source-url

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -5,10 +5,10 @@
     "description" : "A client library for the Ridiculously Simple Configuration System",
     "author" : "Brad Clawsie",
     "provides" : {
-        "DB::RSCS" : "lib/DB/Rscs.pm6"
+        "DB::Rscs" : "lib/DB/Rscs.pm6"
     },
     "depends" : [ "HTTP::UserAgent", "JSON::Tiny" ],
     "test-depends" : [ "HTTP::UserAgent", "JSON::Tiny" ],
     "build-depends" : [ "HTTP::UserAgent", "JSON::Tiny" ],
-    "source-url" : "git://github.com/bradclawsie/DB-Rscs.git"
+    "source-url" : "https://github.com/bradclawsie/DB-Rscs.git"
 }


### PR DESCRIPTION
zef no longer adds `-Ilib` during installation, so modules are not auto-magically
installed, hence the correct name (which is case-sensitive) must be used for the
module to work. At the same time, fix source-url protocol.